### PR TITLE
fix: replace N+1 vault item count queries with batch method

### DIFF
--- a/src/stores/itemStore.ts
+++ b/src/stores/itemStore.ts
@@ -358,13 +358,12 @@ export const useItemStore = create<ItemState & ItemActions>((set, get) => ({
       if (navigator.onLine) {
         const vaults = await DatabaseService.getVaults(user.id, masterKey);
 
-        // Get actual item counts
-        const vaultsWithCounts = await Promise.all(
-          vaults.map(async (v) => ({
-            ...v,
-            itemCount: await DatabaseService.getVaultItemCount(v.id),
-          }))
-        );
+        // Get actual item counts in a single batch query
+        const countMap = await DatabaseService.getVaultItemCounts(user.id);
+        const vaultsWithCounts = vaults.map((v) => ({
+          ...v,
+          itemCount: countMap[v.id] ?? 0,
+        }));
 
         set({ vaults: vaultsWithCounts, isLoading: false });
       } else {


### PR DESCRIPTION
## Summary\n\nFixes #31 — N+1 database queries for vault item counts in `itemStore`.\n\n## Problem\n\nThe `loadVaults` method in `itemStore.ts` was firing one `getVaultItemCount` query per vault using `Promise.all`, causing N+1 database queries. For a user with 10 vaults, this meant 10 separate DB calls.\n\n## Fix\n\nReplaced the per-vault `getVaultItemCount` calls with the existing batch `DatabaseService.getVaultItemCounts(userId)` method (already used in `vaultStore.ts`), which returns all counts in a single query.\n\n### Before\n```typescript\nconst vaultsWithCounts = await Promise.all(\n  vaults.map(async (v) => ({\n    ...v,\n    itemCount: await DatabaseService.getVaultItemCount(v.id),\n  }))\n);\n```\n\n### After\n```typescript\nconst countMap = await DatabaseService.getVaultItemCounts(user.id);\nconst vaultsWithCounts = vaults.map((v) => ({\n  ...v,\n  itemCount: countMap[v.id] ?? 0,\n}));\n```\n\nThis reduces N+1 queries down to a single batch query, improving load performance for users with multiple vaults.</n"