### PR TITLE
fix: master key not set error blocks onboarding completion (#65)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ dev-docs
 .amazonq
 .github/
 docs/
+.kiro

--- a/src/stores/onboarding.ts
+++ b/src/stores/onboarding.ts
@@ -111,6 +111,7 @@ export const useOnboardingStore = create<OnboardingState & OnboardingActions>()(
 
         // 2. Derive master key from PIN + stored salt
         const masterKey = await EncryptionService.deriveMasterKey(pin, salt);
+        IndexedDBService.setMasterKey(masterKey);
 
         // 3. Save encrypted name
         if (formData.name.trim()) {


### PR DESCRIPTION
## Summary

- `completeOnboarding` derived the master key but never called `IndexedDBService.setMasterKey()` before invoking `IndexedDBService.saveSettings()`, which calls `encryptForDB` internally and throws `"Master key not set"`
- Added a single `IndexedDBService.setMasterKey(masterKey)` call immediately after `deriveMasterKey` in `onboarding.ts`
- `setupMasterPin` (called right after) re-derives the same key from the same salt+PIN and sets it again — this remains a no-op overwrite with identical bytes, so no behaviour changes downstream

## Test plan

- [ ] Sign up a new account and complete all 4 onboarding steps — "Finish Setup" should succeed without error
- [ ] Verify the vault opens and sample data loads correctly (if chosen)
- [ ] Verify the "duplicate key" secondary error no longer appears on a fresh signup (it was a symptom of the first failure causing a partial write)
- [ ] Verify existing PIN unlock flow is unaffected

Closes #65